### PR TITLE
Add WhatsApp support using Baileys

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const dotenv = require('dotenv');
 const helmet = require('helmet');
 const morgan = require('morgan');
+const { initWhatsApp } = require('./whatsapp/baileysClient');
 
 dotenv.config();
 
@@ -19,6 +20,9 @@ mongoose.connect(process.env.MONGO_URI, {
   useUnifiedTopology: true,
 }).then(() => {
   console.log('✅ Connected to MongoDB');
+  initWhatsApp(process.env.MONGO_URI).catch(err => {
+    console.error('❌ WhatsApp init error:', err);
+  });
 }).catch((err) => {
   console.error('❌ MongoDB connection error:', err.message);
 });
@@ -62,6 +66,7 @@ app.use('/api/admissions', require('./routers/admissionRoutes'));
 app.use('/api/fees', require('./routers/feesRoutes'));
 app.use('/api/attendance', require('./routers/attendanceRoutes'));
 app.use('/api/dashboard-stats', require('./routers/dashboardStats'));
+app.use('/api/whatsapp', require('./routers/whatsappRoutes'));
 
 
 // ✅ 404 fallback

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "morgan": "^1.10.0",
     "multer": "^2.0.1",
     "multer-storage-cloudinary": "^4.0.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "pino": "^8.17.0",
+    "@whiskeysockets/baileys": "^6.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/routers/whatsappRoutes.js
+++ b/routers/whatsappRoutes.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const { sendMessage } = require('../whatsapp/baileysClient');
+
+router.post('/send', async (req, res) => {
+  const { jid, text } = req.body;
+  if(!jid || !text) {
+    return res.status(400).json({ success: false, message: 'jid and text are required' });
+  }
+  try {
+    await sendMessage(jid, text);
+    res.json({ success: true });
+  } catch (err) {
+    console.error('WhatsApp send error:', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/whatsapp/baileysClient.js
+++ b/whatsapp/baileysClient.js
@@ -1,0 +1,37 @@
+const { default: makeWASocket, DisconnectReason, useMongoDBAuthState } = require('@whiskeysockets/baileys');
+const { MongoClient } = require('mongodb');
+const P = require('pino');
+
+let sock;
+
+async function initWhatsApp(mongoUri) {
+  const client = new MongoClient(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
+  await client.connect();
+  const { state, saveCreds } = await useMongoDBAuthState(client.db().collection('wa_auth'));
+
+  sock = makeWASocket({
+    auth: state,
+    printQRInTerminal: true,
+    logger: P({ level: 'silent' })
+  });
+
+  sock.ev.on('creds.update', saveCreds);
+
+  sock.ev.on('connection.update', (update) => {
+    const { connection, lastDisconnect } = update;
+    if (connection === 'close') {
+      const shouldReconnect = lastDisconnect?.error?.output?.statusCode !== DisconnectReason.loggedOut;
+      console.log('WhatsApp connection closed:', lastDisconnect?.error);
+      if (shouldReconnect) initWhatsApp(mongoUri);
+    } else if (connection === 'open') {
+      console.log('WhatsApp connection opened');
+    }
+  });
+}
+
+async function sendMessage(jid, text) {
+  if (!sock) throw new Error('WhatsApp not initialised');
+  await sock.sendMessage(jid, { text });
+}
+
+module.exports = { initWhatsApp, sendMessage };


### PR DESCRIPTION
## Summary
- integrate `@whiskeysockets/baileys` with remote auth stored in MongoDB
- expose `/api/whatsapp/send` endpoint
- hook WhatsApp initialisation after Mongo connection
- add required dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d5a9965ec832284e6f7903b1eabc6